### PR TITLE
Update clang-extract to llvm+clang 3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CXXFLAGS := -I$(LLVM_DIR)/include -I$(LLVM_DIR)/tools/clang/include \
 	-Wno-variadic-macros -Wno-reorder -Wno-trigraphs -Wno-unknown-pragmas -Wno-unused
 LDFLAGS := -L$(LLVM_DIR)/$(CONFIG)/lib
 LIBS := -lclangFrontend -lclangSerialization -lclangParse -lclangSema -lclangAnalysis -lclangAST \
-	-lclangLex -lclangBasic -lLLVMMC -lLLVMCore -lLLVMSupport -lpthread -ldl -lm
+	-lclangLex -lclangBasic -lclangEdit -lLLVMMC -lLLVMCore -lLLVMSupport -lpthread -ldl -lm
 
 ifeq ($(CONFIG),"Debug")
 	CXXFLAGS += -DDEBUG -g

--- a/extract.cpp
+++ b/extract.cpp
@@ -183,7 +183,7 @@ void Havok::ExtractASTConsumer::declareImplicitMethods(Decl* declIn)
 // This includes top-level classes, namespaces, typedefs, constants, enums, functions
 // in every included header file. Contained elements are children of a top-level element.
 // Every element that is parsed is in here somewhere
-void Havok::ExtractASTConsumer::HandleTopLevelDecl(DeclGroupRef declGroupIn)
+bool Havok::ExtractASTConsumer::HandleTopLevelDecl(DeclGroupRef declGroupIn)
 {
 	// If there are multiple declarations with the same semantic type in the same scope they are
 	// returned as a group. [ e.g. class A { ... } B; ] Usually each group only contains one declaration.
@@ -192,6 +192,8 @@ void Havok::ExtractASTConsumer::HandleTopLevelDecl(DeclGroupRef declGroupIn)
 		declareImplicitMethods(*iter);
 		m_decls.push_back(*iter);
 	}
+
+	return true;
 }
 
 void Havok::ExtractASTConsumer::dumpAllDeclarations()

--- a/extract.h
+++ b/extract.h
@@ -24,7 +24,7 @@ namespace Havok
 			virtual void Initialize(ASTContext& context);
 			virtual void InitializeSema(Sema& sema);
 			// Base callback coming from LLVM (used to accumulate all declarations)
-			virtual void HandleTopLevelDecl(DeclGroupRef DG);
+			virtual bool HandleTopLevelDecl(DeclGroupRef DG);
 
 			enum DumpBits
 			{

--- a/main.cpp
+++ b/main.cpp
@@ -48,7 +48,7 @@ namespace Havok
 	{
 		public:
 
-			virtual ModuleKey loadModule(SourceLocation, IdentifierInfo&, SourceLocation)
+			virtual Module* loadModule(SourceLocation, ModuleIdPath, Module::NameVisibilityKind, bool)
 			{
 				assert(0);
 				return 0;
@@ -147,12 +147,12 @@ int main(int argc, char **argv)
 		diagnostics.setDiagnosticMapping(clang::diag::warn_undefined_internal, clang::diag::MAP_IGNORE, clang::SourceLocation()); //-Wno-undefined-internal
 
 		clang::TargetOptions targetOptions;
-		targetOptions.Triple = llvm::sys::getHostTriple();
+		targetOptions.Triple = llvm::sys::getDefaultTargetTriple();
 		llvm::IntrusiveRefCntPtr<clang::TargetInfo> targetInfo( clang::TargetInfo::CreateTargetInfo(diagnostics, targetOptions ) );	
 		clang::FileSystemOptions filesystemOptions;
 		clang::FileManager fileManager(filesystemOptions);
 		clang::SourceManager sourceManager(diagnostics, fileManager);
-		clang::HeaderSearch headerSearch(fileManager);
+
 		Havok::ModuleLoader moduleLoader;
 		clang::LangOptions langOptions;
 		langOptions.CPlusPlus = 1;
@@ -162,6 +162,8 @@ int main(int argc, char **argv)
 		langOptions.AssumeSaneOperatorNew = 1;
 		langOptions.ImplicitInt = 0;
 		langOptions.ElideConstructors = 0;
+
+		clang::HeaderSearch headerSearch(fileManager, diagnostics, langOptions, targetInfo.getPtr());
 
 		clang::Preprocessor preprocessor(diagnostics, langOptions, targetInfo.getPtr(), sourceManager, headerSearch, moduleLoader);
 		


### PR DESCRIPTION
Some minor changes required to get building with current version.
